### PR TITLE
fix: realm-export add a redirect uri

### DIFF
--- a/keycloak-config/realm-export.json
+++ b/keycloak-config/realm-export.json
@@ -27,7 +27,7 @@
       "publicClient": true,
       "rootUrl": "http://localhost:5173",
       "baseUrl": "http://localhost:5173",
-      "redirectUris": ["http://localhost:5173/*", "http://localhost:5174/*"],
+      "redirectUris": ["http://localhost:5173/*", "http://localhost:5174/*", "http://localhost/explore"],
       "webOrigins": ["http://localhost:5173", "http://localhost:5174"],
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": true,


### PR DESCRIPTION
i need this for the central repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration to support redirects to http://localhost/explore as a valid post-authentication destination.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->